### PR TITLE
Remove devServer.static to prevent header warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,10 +28,6 @@ module.exports = {
     }),
   ],
   devServer: {
-    static: {
-      // public/ klasöründeki sabit dosyaları (index.html) sun
-      directory: path.join(__dirname, 'public'),
-    },
     compress: true,
     port: 8080,
     hot: true,


### PR DESCRIPTION
## Summary
- remove the static serving from `webpack.config.js` to avoid double responses

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ba8dd2e048326a26dd46015793da3