### PR TITLE
Fix react routing for packaged build

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,7 @@
 // src/index.jsx
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -23,7 +23,7 @@ function App() {
         }
       }} />
 
-      <BrowserRouter>
+      <HashRouter>
         <div style={{
           display: 'flex',
           height: '100vh',
@@ -42,7 +42,7 @@ function App() {
             </Routes>
           </div>
         </div>
-      </BrowserRouter>
+      </HashRouter>
     </ThemeProvider>
   );
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'renderer.js',
-    publicPath: './',                 // Base path for assets in dev
+    publicPath: '/',                 // Base path for assets
     assetModuleFilename: 'images/[hash][ext][query]',
   },
   resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'renderer.js',
-    publicPath: '/',                 // Base path for assets
+    // Use absolute path in dev server and relative path in production so
+    // packaged builds load assets correctly from the filesystem
+    publicPath: process.env.NODE_ENV === 'production' ? './' : '/',
     assetModuleFilename: 'images/[hash][ext][query]',
   },
   resolve: {
@@ -42,9 +44,10 @@ module.exports = {
     }),
   ],
   devServer: {
-    static: {
-      directory: path.join(__dirname, 'public'),  // serve index.html
-    },
+    // Let webpack-dev-server serve files from memory only. The template
+    // is handled by HtmlWebpackPlugin, so serving the public folder is
+    // unnecessary and can cause duplicate responses.
+    static: false,
     compress: true,
     port: 8080,
     hot: true,


### PR DESCRIPTION
## Summary
- use `HashRouter` instead of `BrowserRouter`
- adjust webpack `publicPath`

## Testing
- `npm run build-renderer` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be004034c8326bb62e780282c6625