### PR TITLE
Fix Home runtime error with safe styles

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: 16, color: 'red' }}>
+          Something went wrong.
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/features/Home/components/LeftPanel.tsx
+++ b/src/features/Home/components/LeftPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import styles from '../home.module.css';
+import importedStyles from '../home.module.css';
+const styles = importedStyles ?? {} as Record<string, string>;
 
 interface Props {
   onSendToTerminal: () => void;

--- a/src/features/Home/components/RightPanel.tsx
+++ b/src/features/Home/components/RightPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import styles from '../home.module.css';
+import importedStyles from '../home.module.css';
+const styles = importedStyles ?? {} as Record<string, string>;
 
 interface Log {
   time: string;

--- a/src/features/Home/components/StatusBar.tsx
+++ b/src/features/Home/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import styles from '../home.module.css';
+import importedStyles from '../home.module.css';
+const styles = importedStyles ?? {} as Record<string, string>;
 
 export default function StatusBar() {
   return (

--- a/src/features/Home/components/TitleBar.tsx
+++ b/src/features/Home/components/TitleBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import styles from '../home.module.css';
+import importedStyles from '../home.module.css';
+const styles = importedStyles ?? {} as Record<string, string>;
 
 export default function TitleBar() {
   return (

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import styles from './home.module.css'; 
+import importedStyles from './home.module.css';
+const styles = importedStyles ?? {} as Record<string, string>;
 import TitleBar from './components/TitleBar';
 import LeftPanel from './components/LeftPanel';
 import RightPanel from './components/RightPanel';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,7 @@ import GlobalStyles from '@mui/material/GlobalStyles';
 import CssBaseline from '@mui/material/CssBaseline';
 import Sidebar from './components/Sidebar';
 import LoadingOverlay from './components/LoadingOverlay';
+import ErrorBoundary from './components/ErrorBoundary';
 
 import theme from './theme';
 
@@ -56,7 +57,11 @@ function App() {
           }}>
             <Sidebar />
             <Routes>
-              <Route path="/" element={<Home />} />
+              <Route path="/" element={
+                <ErrorBoundary>
+                  <Home />
+                </ErrorBoundary>
+              } />
             </Routes>
 
           </div>


### PR DESCRIPTION
## Summary
- use optional CSS module imports in Home feature
- handle missing style imports across Home components
- add an `ErrorBoundary` component
- wrap the `Home` route with the new error boundary

## Testing
- `npm run build-renderer` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889c8d50d148326bd7387a76d2d2f18