### PR TITLE
Fix style access in Home components

### DIFF
--- a/src/features/Home/components/LeftPanel.tsx
+++ b/src/features/Home/components/LeftPanel.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styles from '../home.module.css';
 
+const classes = styles || {} as Record<string, string>;
+
 interface Props {
   onSendToTerminal: () => void;
   onSendFromTerminal: () => void;
@@ -8,14 +10,14 @@ interface Props {
 
 export default function LeftPanel({ onSendToTerminal, onSendFromTerminal }: Props) {
   return (
-    <div className={styles.leftPanel}>
-      <button onClick={onSendToTerminal} className={styles.primaryButton}>
+    <div className={classes.leftPanel}>
+      <button onClick={onSendToTerminal} className={classes.primaryButton}>
         <span style={{ fontWeight: 'bold' }}>⌨</span>
-        <span className={styles.buttonText}>Sayım Verisi AI ve Terminale Gönder</span>
+        <span className={classes.buttonText}>Sayım Verisi AI ve Terminale Gönder</span>
       </button>
-      <button onClick={onSendFromTerminal} className={styles.secondaryButton}>
+      <button onClick={onSendFromTerminal} className={classes.secondaryButton}>
         <span style={{ fontWeight: 'bold' }}>🖥</span>
-        <span className={styles.buttonText}>Terminalden Verileri AI ye Otomasyona Gönder</span>
+        <span className={classes.buttonText}>Terminalden Verileri AI ye Otomasyona Gönder</span>
       </button>
     </div>
   );

--- a/src/features/Home/components/RightPanel.tsx
+++ b/src/features/Home/components/RightPanel.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styles from '../home.module.css';
 
+const classes = styles || {} as Record<string, string>;
+
 interface Log {
   time: string;
   message: string;
@@ -13,15 +15,15 @@ interface Props {
 
 export default function RightPanel({ logs }: Props) {
   return (
-    <div className={styles.rightPanel}>
-      <div className={styles.logBox}>
-        <div className={styles.logList}>
+    <div className={classes.rightPanel}>
+      <div className={classes.logBox}>
+        <div className={classes.logList}>
           {logs.map((log, index) => (
             <div key={index} style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '8px', animation: 'fade-in 0.3s ease-out' }}>
-              <span className={styles.logTime}>{log.time}</span>
+              <span className={classes.logTime}>{log.time}</span>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <div className={styles.logDot} style={{ backgroundColor: log.type === 'success' ? '#22c55e' : log.type === 'error' ? '#ef4444' : '#3b82f6' }}></div>
-                <span className={styles.logMessage}>{log.message}</span>
+                <div className={classes.logDot} style={{ backgroundColor: log.type === 'success' ? '#22c55e' : log.type === 'error' ? '#ef4444' : '#3b82f6' }}></div>
+                <span className={classes.logMessage}>{log.message}</span>
               </div>
             </div>
           ))}

--- a/src/features/Home/components/StatusBar.tsx
+++ b/src/features/Home/components/StatusBar.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import styles from '../home.module.css';
 
+const classes = styles || {} as Record<string, string>;
+
 export default function StatusBar() {
   return (
-    <div className={styles.statusBar}>
+    <div className={classes.statusBar}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-          <div className={styles.dot} style={{ backgroundColor: '#22c55e' }}></div>
-          <span className={styles.statusText}>Versiyon: V.1.0.0.7</span>
+          <div className={classes.dot} style={{ backgroundColor: '#22c55e' }}></div>
+          <span className={classes.statusText}>Versiyon: V.1.0.0.7</span>
         </div>
-        <button className={styles.linkButton}>📄<span>Kullanıcı Dokümanı</span></button>
+        <button className={classes.linkButton}>📄<span>Kullanıcı Dokümanı</span></button>
       </div>
       <div style={{ display: 'flex', gap: '8px' }}>
-        <button className={styles.statusButton}>Ekranı Aç</button>
-        <button className={styles.statusButton}>Ekranı Kapat</button>
+        <button className={classes.statusButton}>Ekranı Aç</button>
+        <button className={classes.statusButton}>Ekranı Kapat</button>
       </div>
     </div>
   );

--- a/src/features/Home/components/TitleBar.tsx
+++ b/src/features/Home/components/TitleBar.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import styles from '../home.module.css';
 
+const classes = styles || {} as Record<string, string>;
+
 export default function TitleBar() {
   return (
-    <div className={styles.progressBarBg}>
-      <div className={styles.progressBarFill}></div>
-      <div className={styles.titleBar}>
-        <div className={styles.title}>1.Sayım Aşaması</div>
+    <div className={classes.progressBarBg}>
+      <div className={classes.progressBarFill}></div>
+      <div className={classes.titleBar}>
+        <div className={classes.title}>1.Sayım Aşaması</div>
         <div style={{ marginRight: 5, cursor: 'pointer' }}>
           <RefreshIcon />
         </div>

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import styles from './home.module.css'; 
+import styles from './home.module.css';
+
+// Fallback in case CSS modules fail to load
+const classes = styles || {} as Record<string, string>;
 import TitleBar from './components/TitleBar';
 import LeftPanel from './components/LeftPanel';
 import RightPanel from './components/RightPanel';
@@ -10,9 +13,9 @@ export default function Home() {
   const { logs, handleSendFromTerminal, handleSendToTerminal } = useHome();
 
   return (
-    <div className={styles.wrapper}>
+    <div className={classes.wrapper}>
       <TitleBar />
-      <div className={styles.content}>
+      <div className={classes.content}>
         <LeftPanel
           onSendFromTerminal={handleSendFromTerminal}
           onSendToTerminal={handleSendToTerminal}


### PR DESCRIPTION
## Summary
- avoid crash when CSS modules fail to load by falling back to an empty object
- update Home and its child components to use the fallback

## Testing
- `npm install` *(fails: internet access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6889c8d50d148326bd7387a76d2d2f18