### PR TITLE
Fix theme errors and apply colors

### DIFF
--- a/src/features/Home/components/TitleBar.tsx
+++ b/src/features/Home/components/TitleBar.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
+import { useTheme } from '@mui/material/styles';
 import RefreshIcon from '@mui/icons-material/Refresh';
 const styles = require('../home.module.css');
 
 
 export default function TitleBar() {
+  const theme = useTheme();
   return (
     <div className={styles.progressBarBg}>
-      <div className={styles.progressBarFill}></div>
+      <div
+        className={styles.progressBarFill}
+        style={{
+          background: `linear-gradient(to right, ${theme.customColors.gradient.join(", ")})`,
+        }}
+      ></div>
       <div className={styles.titleBar}>
         <div className={styles.title}>1.Sayım Aşaması</div>
         <div style={{ marginRight: 5, cursor: 'pointer' }}>

--- a/src/features/Home/home.module.css
+++ b/src/features/Home/home.module.css
@@ -63,6 +63,7 @@
 
 .leftPanel {
   width: 208px;
+  max-height: 250px;
   background-color: var(--left-panel-bg);
   border-right: 1px solid #475569;
   padding: 16px;
@@ -106,6 +107,7 @@
 .rightPanel {
   flex: 1;
   padding: 16px;
+  max-height: 250px;
 }
 
 .logBox {

--- a/src/features/Home/index.tsx
+++ b/src/features/Home/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTheme } from '@mui/material/styles';
 import TitleBar from './components/TitleBar';
 import LeftPanel from './components/LeftPanel';
 import RightPanel from './components/RightPanel';
@@ -7,10 +8,24 @@ import { useHome } from './useHome';
 const styles = require('./home.module.css');
 
 export default function Home() {
+  const theme = useTheme();
   const { logs, handleSendFromTerminal, handleSendToTerminal } = useHome();
 
+  const cssVars: React.CSSProperties = {
+    '--wrapper-bg': theme.customColors.wrapperBg,
+    '--text-color': theme.customColors.textColor,
+    '--progress-bar-bg': theme.customColors.progressBarBg,
+    '--left-panel-bg': theme.customColors.leftPanelBg,
+    '--logbox-bg': theme.customColors.logboxBg,
+    '--statusbar-bg': theme.customColors.statusbarBg,
+    '--status-text': theme.customColors.statusText,
+    '--link-color': theme.customColors.linkColor,
+    '--status-button-bg': theme.customColors.statusButtonBg,
+    '--status-button-text': theme.customColors.statusButtonText,
+  } as React.CSSProperties;
+
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} style={cssVars}>
       <TitleBar />
       <div className={styles.content}>
         <LeftPanel

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,4 +1,3 @@
-// src/theme/theme.ts
 import { createTheme } from '@mui/material/styles';
 
 declare module '@mui/material/styles' {
@@ -27,7 +26,6 @@ declare module '@mui/material/styles' {
   }
 }
 
-
 export const getTheme = (mode: 'light' | 'dark') =>
   createTheme({
     palette: {
@@ -43,25 +41,25 @@ export const getTheme = (mode: 'light' | 'dark') =>
       },
     },
     customColors: {
-      headerBackground: mode === 'dark' ? '#121212' : '#ECECEC',
-      border: mode === 'dark' ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)',
+      headerBackground: mode === 'dark' ? '#121212' : '#F5F5F5',
+      border: mode === 'dark' ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.1)',
       shadow: mode === 'dark' ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.05)',
       legendBoxBg: mode === 'dark'
         ? 'rgba(30, 30, 40, 0.8)'
-        : 'rgba(255,255,255,0.95)',
+        : 'rgba(255,255,255,0.9)',
       gradient:
         mode === 'dark'
           ? ['#0f3443', '#19324c', '#105e62', '#27ae60']
-          : ['#67e8f9', '#b9ffb7', '#a8ff78', '#27ae60'],
-      wrapperBg: mode === 'dark' ? '#0f172a' : '#ffffff',
+          : ['#ECEFF1', '#CFD8DC', '#B0BEC5', '#90A4AE'],
+      wrapperBg: mode === 'dark' ? '#0f172a' : '#FAFAFA',
       textColor: mode === 'dark' ? '#f1f5f9' : '#1e293b',
       progressBarBg: mode === 'dark' ? '#1e293b' : '#e2e8f0',
-      leftPanelBg: mode === 'dark' ? '#1e293b' : '#f8fafc',
-      logboxBg: mode === 'dark' ? '#0f172a' : '#ffffff',
-      statusbarBg: mode === 'dark' ? '#1e293b' : '#e5e7eb',
+      leftPanelBg: mode === 'dark' ? '#1e293b' : '#FFFFFF',
+      logboxBg: mode === 'dark' ? '#0f172a' : '#FFFFFF',
+      statusbarBg: mode === 'dark' ? '#1e293b' : '#F1F5F9',
       statusText: mode === 'dark' ? '#cbd5e1' : '#475569',
       linkColor: mode === 'dark' ? '#38bdf8' : '#2563eb',
-      statusButtonBg: mode === 'dark' ? '#334155' : '#e2e8f0',
+      statusButtonBg: mode === 'dark' ? '#334155' : '#F1F3F5',
       statusButtonText: mode === 'dark' ? '#f1f5f9' : '#1e293b',
     },
     typography: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,6 +1,32 @@
 // src/theme/theme.ts
 import { createTheme } from '@mui/material/styles';
 
+declare module '@mui/material/styles' {
+  interface CustomColors {
+    headerBackground: string;
+    border: string;
+    shadow: string;
+    legendBoxBg: string;
+    gradient: string[];
+    wrapperBg: string;
+    textColor: string;
+    progressBarBg: string;
+    leftPanelBg: string;
+    logboxBg: string;
+    statusbarBg: string;
+    statusText: string;
+    linkColor: string;
+    statusButtonBg: string;
+    statusButtonText: string;
+  }
+  interface Theme {
+    customColors: CustomColors;
+  }
+  interface ThemeOptions {
+    customColors?: Partial<CustomColors>;
+  }
+}
+
 
 export const getTheme = (mode: 'light' | 'dark') =>
   createTheme({
@@ -27,9 +53,19 @@ export const getTheme = (mode: 'light' | 'dark') =>
         mode === 'dark'
           ? ['#0f3443', '#19324c', '#105e62', '#27ae60']
           : ['#67e8f9', '#b9ffb7', '#a8ff78', '#27ae60'],
+      wrapperBg: mode === 'dark' ? '#0f172a' : '#ffffff',
+      textColor: mode === 'dark' ? '#f1f5f9' : '#1e293b',
+      progressBarBg: mode === 'dark' ? '#1e293b' : '#e2e8f0',
+      leftPanelBg: mode === 'dark' ? '#1e293b' : '#f8fafc',
+      logboxBg: mode === 'dark' ? '#0f172a' : '#ffffff',
+      statusbarBg: mode === 'dark' ? '#1e293b' : '#e5e7eb',
+      statusText: mode === 'dark' ? '#cbd5e1' : '#475569',
+      linkColor: mode === 'dark' ? '#38bdf8' : '#2563eb',
+      statusButtonBg: mode === 'dark' ? '#334155' : '#e2e8f0',
+      statusButtonText: mode === 'dark' ? '#f1f5f9' : '#1e293b',
     },
     typography: {
       fontFamily: ['TTForsRegular', 'sans-serif'].join(','),
       button: { textTransform: 'none' },
     },
-  }) as any;
+  }) as unknown as import('@mui/material/styles').Theme;


### PR DESCRIPTION
## Summary
- extend theme typings with customColors
- provide color values for light and dark mode
- use theme colors in Home and TitleBar components

## Testing
- `npm run build-renderer` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d89f7b248326a875bd229d01042f