### PR TITLE
Add login flow and window controls

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,1 @@
+declare module '*.png';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useContext } from 'react';
 import { ThemeProvider, useTheme, createTheme } from '@mui/material/styles';
 import { CssBaseline, GlobalStyles } from '@mui/material'; 
 import { getTheme } from './theme/theme';
@@ -7,7 +7,8 @@ import Home from './features/Home';
 import Login from './features/Login';
 import Sidebar from './components/Sidebar';
 import LoadingOverlay from './components/LoadingOverlay';
-import { HashRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { AuthContext } from './context/AuthContext';
 
 const STORAGE_KEY = 'mui_app_theme';
 
@@ -17,7 +18,7 @@ export const ColorModeContext = React.createContext({
 });
 
 export default function App() {
-  const isLogin = true;
+  const { isAuthenticated } = useContext(AuthContext);
   const [loading, setLoading] = useState(false);
   const [mode, setMode] = useState<'light' | 'dark'>('dark');
 
@@ -67,10 +68,19 @@ export default function App() {
         <LoadingOverlay open={loading} />
         <HashRouter>
           <div style={{ display: 'flex', height: '100%', flexDirection: 'column' }}>
-            <Sidebar />
+            {isAuthenticated && <Sidebar />}
             <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/login" element={<Login />} />
+              {isAuthenticated ? (
+                <>
+                  <Route path="/*" element={<Home />} />
+                  <Route path="*" element={<Navigate to="/" />} />
+                </>
+              ) : (
+                <>
+                  <Route path="/login" element={<Login />} />
+                  <Route path="*" element={<Navigate to="/login" />} />
+                </>
+              )}
             </Routes>
           </div>
         </HashRouter>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,12 +1,34 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import IconButton from '@mui/material/IconButton';
 import ReactLogo from '@/assets/img/a-101-logo.png';
 
 import CloseIcon from '@mui/icons-material/Close';
 import RemoveIcon from '@mui/icons-material/Minimize';
 import LogoutIcon from '@mui/icons-material/Logout';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '@/context/AuthContext';
 
 export default function TopNav() {
+  const navigate = useNavigate();
+  const { logout } = useContext(AuthContext);
+
+  const handleClose = () => {
+    const remote = window.require('@electron/remote');
+    const win = remote.getCurrentWindow ? remote.getCurrentWindow() : remote.BrowserWindow.getFocusedWindow();
+    if (win) win.close();
+  };
+
+  const handleMinimize = () => {
+    const remote = window.require('@electron/remote');
+    const win = remote.getCurrentWindow ? remote.getCurrentWindow() : remote.BrowserWindow.getFocusedWindow();
+    if (win) win.minimize();
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
   return (
     <div style={styles.wrapper}>
       {/* SOL: Logo */}
@@ -26,15 +48,15 @@ export default function TopNav() {
           B5954 - Kışla Sancaktepe İstanbul
         </div>
 
-        <IconButton size="small" sx={{ color: 'white' }} title="Çıkış Yap">
+        <IconButton size="small" sx={{ color: 'white' }} title="Çıkış Yap" onClick={handleLogout}>
           <LogoutIcon fontSize="small" />
         </IconButton>
 
-        <IconButton size="small" sx={{ color: 'white' }} title="Küçült">
+        <IconButton size="small" sx={{ color: 'white' }} title="Küçült" onClick={handleMinimize}>
           <RemoveIcon fontSize="small" />
         </IconButton>
 
-        <IconButton size="small" sx={{ color: 'white' }} title="Kapat">
+        <IconButton size="small" sx={{ color: 'white' }} title="Kapat" onClick={handleClose}>
           <CloseIcon fontSize="small" />
         </IconButton>
       </div>

--- a/src/components/SnackbarAlert.tsx
+++ b/src/components/SnackbarAlert.tsx
@@ -1,0 +1,18 @@
+
+import React from 'react';
+import { Snackbar, Alert, AlertColor } from '@mui/material';
+
+interface SnackbarAlertProps {
+  open: boolean;
+  message: string;
+  severity: AlertColor;
+  onClose: () => void;
+}
+
+export const SnackbarAlert: React.FC<SnackbarAlertProps> = ({ open, message, severity, onClose }) => (
+  <Snackbar open={open} autoHideDuration={3000} onClose={onClose} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+    <Alert onClose={onClose} severity={severity} variant="filled">
+      {message}
+    </Alert>
+  </Snackbar>
+);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useState } from 'react';
+
+interface AuthContextProps {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextProps>({
+  isAuthenticated: false,
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  const login = () => setIsAuthenticated(true);
+  const logout = () => setIsAuthenticated(false);
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/features/Login/Login.module.css
+++ b/src/features/Login/Login.module.css
@@ -1,0 +1,44 @@
+ .wrapper {
+   min-height: 100vh;
+   display: flex;
+   align-items: center;
+   justify-content: center;
+
+ }
+
+ .card {
+   max-width: 360px;
+   width: 100%;
+   padding: 14px;
+   border-radius: 8px !important;
+   background-color: 'red';
+   text-align: center;
+   
+ }
+
+ .logo {
+   height: 48px;
+ }
+
+ .title {
+   margin: 5px 0 15px 0 !important;
+   font-size: 14px !important;
+   font-weight: bold !important;
+ }
+
+ .form {
+   display: flex;
+   flex-direction: column;
+   gap: 16px;
+ }
+
+ .dialogTitle {
+   text-align: center;
+ }
+
+ .dialogContent {
+   display: flex;
+   flex-direction: column;
+   gap: 16px;
+
+ }

--- a/src/features/Login/components/BSDialog.tsx
+++ b/src/features/Login/components/BSDialog.tsx
@@ -1,0 +1,55 @@
+
+// src/features/Login/components/BSDialog.tsx
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+} from '@mui/material';
+import styles from '../Login.module.css';
+
+interface BSDialogProps {
+  open: boolean;
+  bsUser: string;
+  bsPass: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+  styles: Record<string, string>;
+
+}
+
+const BSDialog: React.FC<BSDialogProps> = ({ open, bsUser, bsPass, onChange, onClose, onSubmit, styles }) => (
+  <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+    <DialogTitle className={styles.dialogTitle}>BS Kullanıcı Giriş</DialogTitle>
+    <DialogContent className={styles.dialogContent}>
+      <div style={{ marginTop: 5 }}>
+        <TextField
+          name="bsUser"
+          label="Kullanıcı Adı"
+          value={bsUser}
+          onChange={onChange}
+          fullWidth
+        />
+        <TextField
+          name="bsPass"
+          type="password"
+          label="Şifre"
+          value={bsPass}
+          onChange={onChange}
+          fullWidth
+          style={{ marginTop: 16 }}
+        />
+      </div>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose}>İptal</Button>
+      <Button variant="contained" onClick={onSubmit} style={{ color: '#fff' }}>Giriş Yap</Button>
+    </DialogActions>
+  </Dialog>
+);
+
+export default BSDialog;

--- a/src/features/Login/components/LoginForm.tsx
+++ b/src/features/Login/components/LoginForm.tsx
@@ -1,0 +1,41 @@
+
+import React from 'react';
+import { Box, TextField, Button } from '@mui/material';
+
+interface LoginFormProps {
+  storeCode: string;
+  storePass: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: () => void;
+  styles: Record<string, string>;
+}
+
+const LoginForm: React.FC<LoginFormProps> = ({ storeCode, storePass, onChange, onSubmit, styles }) => (
+  <Box component="form" className={styles.form} noValidate>
+    <TextField
+      name="storeCode"
+      label="Mağaza Kodu"
+      value={storeCode}
+      onChange={onChange}
+      fullWidth
+    />
+    <TextField
+      name="storePass"
+      type="password"
+      label="Şifre"
+      value={storePass}
+      onChange={onChange}
+      fullWidth
+    />
+    <Button
+      variant="contained"
+      onClick={onSubmit}
+      fullWidth
+      style={{ color: '#fff' }}
+    >
+      Devam Et
+    </Button>
+  </Box>
+);
+
+export default LoginForm;

--- a/src/features/Login/index.jsx
+++ b/src/features/Login/index.jsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-export default function About() {
-  return (
-    <div>
-      <h1>!</h1> 
-    </div>
-  );
-}

--- a/src/features/Login/index.tsx
+++ b/src/features/Login/index.tsx
@@ -1,53 +1,69 @@
-import React, { useState, useContext } from 'react';
-import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
-import { AuthContext } from '@/context/AuthContext';
 
-export default function Login() {
-  const navigate = useNavigate();
-  const { login } = useContext(AuthContext);
+import React from 'react';
+import { Box, Paper, Typography, useTheme } from '@mui/material';;
+import LoginForm from './components/LoginForm';
+import BSDialog from './components/BSDialog';
+import { SnackbarAlert } from '../../components/SnackbarAlert';
+import useLogin from './useLogin'; 
+const Logo = require('../../assets/img/a-101-logo.png');
+const styles = require('./Login.module.css');
 
-  const [storeCode, setStoreCode] = useState('');
-  const [storePass, setStorePass] = useState('');
-  const [bsUser, setBsUser] = useState('');
-  const [bsPass, setBsPass] = useState('');
-  const [openBs, setOpenBs] = useState(false);
-
-  const handleFirst = () => {
-    if (storeCode === 'admin' && storePass === 'admin') {
-      setOpenBs(true);
-    } else {
-      alert('Mağaza kodu veya şifre hatalı');
-    }
-  };
-
-  const handleSecond = () => {
-    if (bsUser === 'admin' && bsPass === 'admin') {
-      login();
-      navigate('/');
-    } else {
-      alert('Kullanıcı adı veya şifre hatalı');
-    }
-  };
+const Login: React.FC = () => {
+  const theme = useTheme();
+  const {
+    storeCode,
+    storePass,
+    bsUser,
+    bsPass,
+    openBs,
+    snackbar,
+    handleChange,
+    handleFirst,
+    handleSecond,
+    closeSnackbar,
+    closeDialog,
+  } = useLogin();
 
   return (
-    <Box sx={{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 250 }}>
-        <TextField label="Mağaza Kodu" value={storeCode} onChange={e => setStoreCode(e.target.value)} fullWidth />
-        <TextField label="Şifre" type="password" value={storePass} onChange={e => setStorePass(e.target.value)} fullWidth />
-        <Button variant="contained" onClick={handleFirst}>Giriş</Button>
-      </Box>
-      <Dialog open={openBs} onClose={() => setOpenBs(false)}>
-        <DialogTitle>BS Girişi</DialogTitle>
-        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-          <TextField label="Kullanıcı Adı" value={bsUser} onChange={e => setBsUser(e.target.value)} fullWidth />
-          <TextField label="Şifre" type="password" value={bsPass} onChange={e => setBsPass(e.target.value)} fullWidth />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setOpenBs(false)}>İptal</Button>
-          <Button variant="contained" onClick={handleSecond}>Giriş</Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
+    <div
+      className={styles.wrapper}
+      style={{
+        backgroundColor: theme.customColors.wrapperBg,
+        backgroundImage: `linear-gradient(135deg, ${theme.customColors.gradient.join(',')})`,
+      }}
+    >
+      <Paper className={styles.card} elevation={8}>
+        <img src={Logo} alt="Logo" className={styles.logo} />
+        <Typography variant="h6" className={styles.title}>
+          Mağaza Girişi
+        </Typography>
+        <LoginForm
+          storeCode={storeCode}
+          storePass={storePass}
+          onChange={handleChange}
+          onSubmit={handleFirst}
+          styles={styles}
+        />
+      </Paper>
+
+      <BSDialog
+        open={openBs}
+        bsUser={bsUser}
+        bsPass={bsPass}
+        onChange={handleChange}
+        onClose={closeDialog}
+        onSubmit={handleSecond}
+        styles={styles}
+      />
+
+      <SnackbarAlert
+        open={snackbar.open}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
+    </div>
   );
-}
+};
+
+export default Login;

--- a/src/features/Login/index.tsx
+++ b/src/features/Login/index.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useContext } from 'react';
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '@/context/AuthContext';
+
+export default function Login() {
+  const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
+
+  const [storeCode, setStoreCode] = useState('');
+  const [storePass, setStorePass] = useState('');
+  const [bsUser, setBsUser] = useState('');
+  const [bsPass, setBsPass] = useState('');
+  const [openBs, setOpenBs] = useState(false);
+
+  const handleFirst = () => {
+    if (storeCode === 'admin' && storePass === 'admin') {
+      setOpenBs(true);
+    } else {
+      alert('Mağaza kodu veya şifre hatalı');
+    }
+  };
+
+  const handleSecond = () => {
+    if (bsUser === 'admin' && bsPass === 'admin') {
+      login();
+      navigate('/');
+    } else {
+      alert('Kullanıcı adı veya şifre hatalı');
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 250 }}>
+        <TextField label="Mağaza Kodu" value={storeCode} onChange={e => setStoreCode(e.target.value)} fullWidth />
+        <TextField label="Şifre" type="password" value={storePass} onChange={e => setStorePass(e.target.value)} fullWidth />
+        <Button variant="contained" onClick={handleFirst}>Giriş</Button>
+      </Box>
+      <Dialog open={openBs} onClose={() => setOpenBs(false)}>
+        <DialogTitle>BS Girişi</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="Kullanıcı Adı" value={bsUser} onChange={e => setBsUser(e.target.value)} fullWidth />
+          <TextField label="Şifre" type="password" value={bsPass} onChange={e => setBsPass(e.target.value)} fullWidth />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenBs(false)}>İptal</Button>
+          <Button variant="contained" onClick={handleSecond}>Giriş</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/features/Login/useLogin.ts
+++ b/src/features/Login/useLogin.ts
@@ -1,0 +1,65 @@
+
+import { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../../context/AuthContext';
+import { AlertColor } from '@mui/material';
+
+interface UseLoginReturn {
+  storeCode: string;
+  storePass: string;
+  bsUser: string;
+  bsPass: string;
+  openBs: boolean;
+  snackbar: { open: boolean; message: string; severity: AlertColor };
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleFirst: () => void;
+  handleSecond: () => void;
+  closeSnackbar: () => void;
+  closeDialog: () => void;
+}
+
+const useLogin = (): UseLoginReturn => {
+  const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
+
+  const [form, setForm] = useState({ storeCode: 'admin', storePass: 'admin', bsUser: 'admin', bsPass: 'admin' });
+  const [openBs, setOpenBs] = useState(false);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: AlertColor }>({ open: false, message: '', severity: 'error' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const showError = (message: string) => setSnackbar({ open: true, message, severity: 'error' });
+
+  const handleFirst = () => {
+    if (form.storeCode === 'admin' && form.storePass === 'admin') setOpenBs(true);
+    else showError('Mağaza kodu veya şifre yanlış!');
+  };
+
+  const handleSecond = () => {
+    if (form.bsUser === 'admin' && form.bsPass === 'admin') {
+      login();
+      navigate('/');
+    } else showError('BS kullanıcı adı veya şifre yanlış!');
+  };
+
+  const closeSnackbar = () => setSnackbar(s => ({ ...s, open: false }));
+  const closeDialog = () => setOpenBs(false);
+
+  return {
+    storeCode: form.storeCode,
+    storePass: form.storePass,
+    bsUser: form.bsUser,
+    bsPass: form.bsPass,
+    openBs,
+    snackbar,
+    handleChange,
+    handleFirst,
+    handleSecond,
+    closeSnackbar,
+    closeDialog,
+  };
+};
+
+export default useLogin;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
 
 const container = document.getElementById('root');
-createRoot(container).render(<App />);
+createRoot(container).render(
+  <AuthProvider>
+    <App />
+  </AuthProvider>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,8 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "typeRoots": [
-      "./node_modules/@types",
-      "./src/types"
+      "./src/custom.d.ts",
+      "./node_modules/@types"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- add an `AuthContext` to keep login state
- wrap the app with the new context provider
- show login screen until user authenticates
- implement a two-step login form with modal
- connect sidebar icons to minimize/close and logout actions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build-renderer` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889eb49c2908326bec7c2113c5fa72e