### PR TITLE
Implement auth flow and window actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useContext } from 'react';
 import { ThemeProvider, useTheme, createTheme } from '@mui/material/styles';
 import { CssBaseline, GlobalStyles } from '@mui/material'; 
 import { getTheme } from './theme/theme';
@@ -7,7 +7,8 @@ import Home from './features/Home';
 import Login from './features/Login';
 import Sidebar from './components/Sidebar';
 import LoadingOverlay from './components/LoadingOverlay';
-import { HashRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { AuthContext } from './context/AuthContext';
 
 const STORAGE_KEY = 'mui_app_theme';
 
@@ -17,7 +18,7 @@ export const ColorModeContext = React.createContext({
 });
 
 export default function App() {
-  const isLogin = true;
+  const { isAuthenticated } = useContext(AuthContext);
   const [loading, setLoading] = useState(false);
   const [mode, setMode] = useState<'light' | 'dark'>('dark');
 
@@ -67,10 +68,13 @@ export default function App() {
         <LoadingOverlay open={loading} />
         <HashRouter>
           <div style={{ display: 'flex', height: '100%', flexDirection: 'column' }}>
-            <Sidebar />
+            {isAuthenticated && <Sidebar />}
             <Routes>
-              <Route path="/" element={<Home />} />
               <Route path="/login" element={<Login />} />
+              <Route
+                path="/"
+                element={isAuthenticated ? <Home /> : <Navigate to="/login" />}
+              />
             </Routes>
           </div>
         </HashRouter>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,12 +1,33 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import IconButton from '@mui/material/IconButton';
 import ReactLogo from '@/assets/img/a-101-logo.png';
+
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '@/context/AuthContext';
+
+const remote = window.require('@electron/remote');
 
 import CloseIcon from '@mui/icons-material/Close';
 import RemoveIcon from '@mui/icons-material/Minimize';
 import LogoutIcon from '@mui/icons-material/Logout';
 
 export default function TopNav() {
+  const navigate = useNavigate();
+  const { logout } = useContext(AuthContext);
+
+  const handleClose = () => {
+    remote.getCurrentWindow().close();
+  };
+
+  const handleMinimize = () => {
+    remote.getCurrentWindow().minimize();
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
   return (
     <div style={styles.wrapper}>
       {/* SOL: Logo */}
@@ -26,15 +47,15 @@ export default function TopNav() {
           B5954 - Kışla Sancaktepe İstanbul
         </div>
 
-        <IconButton size="small" sx={{ color: 'white' }} title="Çıkış Yap">
+        <IconButton size="small" sx={{ color: 'white' }} title="Çıkış Yap" onClick={handleLogout}>
           <LogoutIcon fontSize="small" />
         </IconButton>
 
-        <IconButton size="small" sx={{ color: 'white' }} title="Küçült">
+        <IconButton size="small" sx={{ color: 'white' }} title="Küçült" onClick={handleMinimize}>
           <RemoveIcon fontSize="small" />
         </IconButton>
 
-        <IconButton size="small" sx={{ color: 'white' }} title="Kapat">
+        <IconButton size="small" sx={{ color: 'white' }} title="Kapat" onClick={handleClose}>
           <CloseIcon fontSize="small" />
         </IconButton>
       </div>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+interface AuthContextType {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType>({
+  isAuthenticated: false,
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('auth');
+    if (stored === 'true') {
+      setIsAuthenticated(true);
+    }
+  }, []);
+
+  const login = () => {
+    setIsAuthenticated(true);
+    localStorage.setItem('auth', 'true');
+  };
+
+  const logout = () => {
+    setIsAuthenticated(false);
+    localStorage.removeItem('auth');
+  };
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/features/Login/index.jsx
+++ b/src/features/Login/index.jsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-export default function About() {
-  return (
-    <div>
-      <h1>!</h1> 
-    </div>
-  );
-}

--- a/src/features/Login/index.tsx
+++ b/src/features/Login/index.tsx
@@ -1,0 +1,64 @@
+import React, { useState, useContext } from 'react';
+import { Modal, Box, TextField, Button } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '@/context/AuthContext';
+
+const modalStyle = {
+  position: 'absolute' as const,
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  backgroundColor: 'white',
+  padding: 20,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  minWidth: 250
+};
+
+export default function Login() {
+  const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
+
+  const [step, setStep] = useState(1);
+  const [storeCode, setStoreCode] = useState('');
+  const [storePass, setStorePass] = useState('');
+  const [userName, setUserName] = useState('');
+  const [userPass, setUserPass] = useState('');
+
+  const handleFirst = () => {
+    if (storeCode === 'admin' && storePass === 'admin') {
+      setStep(2);
+    } else {
+      alert('Mağaza bilgileri hatalı');
+    }
+  };
+
+  const handleSecond = () => {
+    if (userName === 'admin' && userPass === 'admin') {
+      login();
+      navigate('/');
+    } else {
+      alert('Kullanıcı bilgileri hatalı');
+    }
+  };
+
+  return (
+    <>
+      <Modal open={step === 1} hideBackdrop>
+        <Box sx={modalStyle}>
+          <TextField label="Mağaza Kodu" value={storeCode} onChange={e => setStoreCode(e.target.value)} fullWidth />
+          <TextField label="Şifre" type="password" value={storePass} onChange={e => setStorePass(e.target.value)} fullWidth />
+          <Button variant="contained" onClick={handleFirst}>Giriş Yap</Button>
+        </Box>
+      </Modal>
+      <Modal open={step === 2} hideBackdrop>
+        <Box sx={modalStyle}>
+          <TextField label="Kullanıcı Adı" value={userName} onChange={e => setUserName(e.target.value)} fullWidth />
+          <TextField label="Şifre" type="password" value={userPass} onChange={e => setUserPass(e.target.value)} fullWidth />
+          <Button variant="contained" onClick={handleSecond}>Onayla</Button>
+        </Box>
+      </Modal>
+    </>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
 
 const container = document.getElementById('root');
-createRoot(container).render(<App />);
+createRoot(container).render(
+  <AuthProvider>
+    <App />
+  </AuthProvider>
+);


### PR DESCRIPTION
## Summary
- create `AuthContext` to hold login state
- add login modal workflow asking for store and user credentials
- protect routes using new auth context
- show Sidebar only after login
- enable Close, Minimize and Logout actions in Sidebar

## Testing
- `npm run build-renderer` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889eb49c2908326bec7c2113c5fa72e